### PR TITLE
Adjust Oneplus detection

### DIFF
--- a/app/src/main/java/me/phh/treble/app/OnePlusSettings.kt
+++ b/app/src/main/java/me/phh/treble/app/OnePlusSettings.kt
@@ -8,7 +8,7 @@ object OnePlusSettings {
     val highBrightnessModeKey = "key_oneplus_display_high_brightness"
     val usbOtgKey = "key_oneplus_usb_otg"
 
-    fun enabled(): Boolean = Tools.vendorFp.contains("OnePlus6")
+    fun enabled(): Boolean = Tools.vendorFp.contains("OnePlus")
 }
 
 class OnePlusSettingsFragment : PreferenceFragment() {


### PR DESCRIPTION
* Makes Oneplus Settings suitable for all Oneplus devices
  All Oneplus devices could use these features, not only op6