### PR TITLE
[redmi] enable DT2W support too

### DIFF
--- a/app/src/main/java/me/phh/treble/app/XiaomiSettings.kt
+++ b/app/src/main/java/me/phh/treble/app/XiaomiSettings.kt
@@ -4,7 +4,8 @@ package me.phh.treble.app
 object XiaomiSettings : Settings {
     val dt2w = "xiaomi_double_tap_to_wake"
 
-    override fun enabled() = Tools.vendorFp.toLowerCase().startsWith("xiaomi")
+    override fun enabled() = Tools.vendorFp.toLowerCase().startsWith("xiaomi") ||
+                             Tools.vendorFp.toLowerCase().startsWith("redmi/")
 }
 
 class XiaomiSettingsFragment : SettingsFragment() {


### PR DESCRIPTION
  at least Redmi/begonia have it (/dev/input/event2)
  tested & works

	modified:   app/src/main/java/me/phh/treble/app/XiaomiSettings.kt