### PR TITLE
Ims: add SPRD IMS overlay support

### DIFF
--- a/app/src/main/java/me/phh/treble/app/Ims.kt
+++ b/app/src/main/java/me/phh/treble/app/Ims.kt
@@ -71,6 +71,8 @@ object Ims: EntryStartup {
             .find { i -> mHidlService.get("vendor.qti.hardware.radio.ims@1.0::IImsRadio", i) != null } != null
     val gotSLSI = mAllSlots
             .find { i -> mHidlService.get("vendor.samsung_slsi.telephony.hardware.radio@1.0::IOemSamsungslsi", i) != null } != null
+    val gotSPRD = mAllSlots
+            .find { i -> mHidlService.get("vendor.sprd.hardware.radio@1.0::IExtRadio", i) != null } != null
 
 
     override fun startup(ctxt: Context) {
@@ -86,6 +88,7 @@ object Ims: EntryStartup {
             gotMtkPie || gotMtkQuack -> "me.phh.treble.overlay.mtkims_telephony"
             gotQualcomm -> "me.phh.treble.overlay.cafims_telephony"
             gotSLSI -> "me.phh.treble.overlay.slsiims_telephony"
+            gotSPRD -> "me.phh.treble.overlay.sprdims_telephony"
             else -> null
         }
         if(selectOverlay != null) {


### PR DESCRIPTION
Note that I haven't added auto-download support for the SPRD IMS APK because it is not on treble.phh.me. The ims-sprd.apk needs to be patched to support R, and I will send out these patches separately later.