### PR TITLE
Prevent backlight scale value override rw-system

### DIFF
--- a/app/src/main/java/me/phh/treble/app/Misc.kt
+++ b/app/src/main/java/me/phh/treble/app/Misc.kt
@@ -188,8 +188,19 @@ object Misc: EntryStartup {
                 SystemProperties.set("persist.sys.fflag.override.settings_fuse", if (!value) "true" else "false")
             }
             MiscSettings.backlightScale -> {
-                val value = sp.getBoolean(key, false)
-                SystemProperties.set("persist.sys.phh.backlight.scale", if (value) "1" else "0")
+                val value = sp.getString(key, "System Default")
+                android.util.Log.d("PHH", "Setting backlight scale to $value")
+                when (value) {
+                  "System Default" -> { 
+                  SystemProperties.set("persist.sys.phh.backlight.scale","2")
+                  }
+                  "Off" -> {
+                  SystemProperties.set("persist.sys.phh.backlight.scale","0")
+                  }
+                  "On" -> {
+                  SystemProperties.set("persist.sys.phh.backlight.scale","1")
+                  }
+               }
             }
             MiscSettings.headsetDevinput -> {
                 val value = sp.getBoolean(key, false)

--- a/app/src/main/java/me/phh/treble/app/Misc.kt
+++ b/app/src/main/java/me/phh/treble/app/Misc.kt
@@ -191,13 +191,13 @@ object Misc: EntryStartup {
                 val value = sp.getString(key, "System Default")
                 android.util.Log.d("PHH", "Setting backlight scale to $value")
                 when (value) {
-                  "System Default" -> { 
+                  "system default" -> { 
                   SystemProperties.set("persist.sys.phh.backlight.scale","2")
                   }
-                  "Off" -> {
+                  "off" -> {
                   SystemProperties.set("persist.sys.phh.backlight.scale","0")
                   }
-                  "On" -> {
+                  "on" -> {
                   SystemProperties.set("persist.sys.phh.backlight.scale","1")
                   }
                }

--- a/app/src/main/java/me/phh/treble/app/MiscSettings.kt
+++ b/app/src/main/java/me/phh/treble/app/MiscSettings.kt
@@ -30,7 +30,7 @@ object MiscSettings : Settings {
     val forceA2dpOffloadDisable = "key_misc_force_a2dp_offload_disable"
     val noHwcomposer = "key_misc_no_hwcomposer"
     val storageFUSE = "key_misc_storage_fuse"
-    val backlightScale = "key_misc_backlight_scale"
+    val backlightScale = "key_misc_backlight_scale_value"
     val headsetDevinput = "key_misc_headset_devinput"
     val restartRil = "key_misc_restart_ril"
 

--- a/app/src/main/res/values/pref_misc.xml
+++ b/app/src/main/res/values/pref_misc.xml
@@ -67,12 +67,14 @@
       <item>"0"</item>
       <item>"1"</item>
     </array>
-<array name="pref_misc_backlight_scale">
+    <array name="pref_misc_backlight_scale">
         <item>"System Default"</item>
 	    <item>"On"</item>
 	    <item>"Off"</item>
-<array name="pref_misc_backlight_scale_values">
+    </array>	
+    <array name="pref_misc_backlight_scale_values">
 	    <item>"system default"</item>
 	    <item>"on"</item>
 	    <item>"off"</item>
+    </array>
 </resources>

--- a/app/src/main/res/values/pref_misc.xml
+++ b/app/src/main/res/values/pref_misc.xml
@@ -67,4 +67,12 @@
       <item>"0"</item>
       <item>"1"</item>
     </array>
+<array name="pref_misc_backlight_scale">
+        <item>"System Default"</item>
+	    <item>"On"</item>
+	    <item>"Off"</item>
+<array name="pref_misc_backlight_scale_values">
+	    <item>"system default"</item>
+	    <item>"on"</item>
+	    <item>"off"</item>
 </resources>

--- a/app/src/main/res/xml/pref_misc.xml
+++ b/app/src/main/res/xml/pref_misc.xml
@@ -67,10 +67,13 @@
             android:defaultValue="false"
             android:key="key_misc_disable_buttons_backlight"
             android:title="Disable backlight of hardware buttons if present (requires reboot)" />
-		<CheckBoxPreference
-            android:defaultValue="false"
-            android:key="key_misc_backlight_scale"
-            android:title="Force alternative backlight scale" />
+		nceCategory android:title="Other">
+		<ListPreference
+			android:defaultValue="-1"
+			android:entries="@array/pref_misc_backlight_scale"
+			android:entryValues="@array/pref_misc_backlight_scale_values"
+			android:key="key_misc_backlight_scale"
+			android:title="Force alternative backlight scale" />
 	</PreferenceCategory>
 	<PreferenceCategory android:title="Camera">
 		<CheckBoxPreference

--- a/app/src/main/res/xml/pref_misc.xml
+++ b/app/src/main/res/xml/pref_misc.xml
@@ -67,7 +67,6 @@
             android:defaultValue="false"
             android:key="key_misc_disable_buttons_backlight"
             android:title="Disable backlight of hardware buttons if present (requires reboot)" />
-		nceCategory android:title="Other">
 		<ListPreference
 			android:defaultValue="-1"
 			android:entries="@array/pref_misc_backlight_scale"

--- a/app/src/main/res/xml/pref_misc.xml
+++ b/app/src/main/res/xml/pref_misc.xml
@@ -71,7 +71,7 @@
 			android:defaultValue="-1"
 			android:entries="@array/pref_misc_backlight_scale"
 			android:entryValues="@array/pref_misc_backlight_scale_values"
-			android:key="key_misc_backlight_scale"
+			android:key="key_misc_backlight_scale_value"
 			android:title="Force alternative backlight scale" />
 	</PreferenceCategory>
 	<PreferenceCategory android:title="Camera">


### PR DESCRIPTION
Add Tristate value. With Value 2 it does nothing (default)