### PR TITLE
Only show Updater entrypoint when OTA JSON URL is set

### DIFF
--- a/app/src/main/java/me/phh/treble/app/SettingsActivity.kt
+++ b/app/src/main/java/me/phh/treble/app/SettingsActivity.kt
@@ -3,6 +3,7 @@ package me.phh.treble.app
 import android.content.Context
 import android.content.res.Configuration
 import android.os.Bundle
+import android.os.SystemProperties
 import android.preference.PreferenceActivity
 import androidx.preference.ListPreference
 import androidx.preference.Preference
@@ -68,7 +69,10 @@ class SettingsActivity : PreferenceActivity() {
         if (!ImsSettings.enabled())
             target.removeIf { it.fragment == ImsSettingsFragment::class.java.name }
         if (!CustomSettings.enabled())
-            target.removeIf { it.fragment == CustomSettingsFragment::class.java.name }   
+            target.removeIf { it.fragment == CustomSettingsFragment::class.java.name }
+        val p = SystemProperties.get("ro.system.ota.json_url", "")
+        if (p.trim() == "")
+            target.removeIf { it.id.compareTo(R.id.updater) == 0 }
     }
 
     /**

--- a/app/src/main/res/xml/pref_headers.xml
+++ b/app/src/main/res/xml/pref_headers.xml
@@ -41,7 +41,9 @@
     <header
         android:fragment="me.phh.treble.app.CustomSettingsFragment"
         android:title="Customization features" />
-    <header android:title="Updater">
+    <header
+        android:id="@+id/updater"
+        android:title="Updater">
         <intent android:action="android.settings.SYSTEM_UPDATE_SETTINGS"
                 android:targetClass=".UpdaterActivity"/>
     </header>


### PR DESCRIPTION
GSIs without OTA built-in don't need a defunct Updater entry

* Please review the removeIf condition