### PR TITLE
Stop enabling VT / video calling

### DIFF
--- a/app/src/main/java/me/phh/treble/app/Ims.kt
+++ b/app/src/main/java/me/phh/treble/app/Ims.kt
@@ -52,7 +52,6 @@ object Ims: EntryStartup {
             }
             ImsSettings.forceEnableSettings -> {
                 val value = if(sp.getBoolean(key, false)) "1" else "0"
-                Misc.safeSetprop("persist.dbg.vt_avail_ovr", value)
                 Misc.safeSetprop("persist.dbg.volte_avail_ovr", value)
                 Misc.safeSetprop("persist.dbg.wfc_avail_ovr", value)
                 Misc.safeSetprop("persist.dbg.allow_ims_off", value)


### PR DESCRIPTION
Rarely see use, and might crash IMS